### PR TITLE
Path planning and following seems to work

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -44,6 +44,8 @@ public final class Constants {
 
 
   public static final class Drive {
+    public static final double TRACK_WIDTH_METERS = 0.56;
+
     public final static double WHEEL_CIRCUM = 46.8;
     public final static double WHEEL_GEAR_RATIO = 8.46;
     public final static double LEFT_SCALING = (1509 / 1501.89) / 100 ;

--- a/src/main/java/frc/robot/sim/DrivebaseSim.java
+++ b/src/main/java/frc/robot/sim/DrivebaseSim.java
@@ -1,0 +1,152 @@
+package frc.robot.sim;
+
+import javax.swing.text.Position;
+
+import com.revrobotics.CANSparkMax;
+
+import edu.wpi.first.hal.HALValue;
+import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.hal.simulation.SimDeviceDataJNI;
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.simulation.DifferentialDrivetrainSim;
+import frc.robot.Constants.Drive;
+
+/**
+ * Since REVPhysicsSim doesn't work, let's try to implement
+ * our own simulation that updates the relevant simulation
+ * variables for Spark MAX motors.
+ */
+public class DrivebaseSim {
+  // Simulation value handles that are doubles
+  public static final String APPLIED_OUTPUT = "Applied Output";
+  public static final String VELOCITY = "Velocity";
+  public static final String VELOCITY_CONVERSION_FACTOR = "Velocity Conversion Factor";
+  public static final String POSITION = "Position";
+  public static final String POSITION_CONVERSION_FACTOR = "Position Conversion Factor";
+  public static final String BUS_VOLTAGE = "Bus Voltage"; // Always 12.0?
+  public static final String MOTOR_CURRENT = "Motor Current";
+  public static final String ANALOG_VOLTAGE = "Analog Voltage";
+  public static final String ANALOG_VELOCITY = "Analog Velocity";
+  public static final String ANALOG_POSITION = "Analog Position";
+  public static final String ALT_ENCODER_VELOCITY = "Alt Encoder Velocity";
+  public static final String ALT_ENCODER_POSITION = "Alt Encoder Position";
+  public static final String STALL_TORQUE = "Stall Torque";
+  public static final String FREE_SPEED = "Free Speed";
+  
+  // Simulation value handles that are ints
+  public static final String FAULTS = "Faults";
+  public static final String STICKY_FAULTS = "Sticky Faults";
+  public static final String MOTOR_TEMPERATURE = "Motor Temperature"; // Always 25?
+  public static final String CONTROL_MODE = "Control Mode";
+  public static final String FW_VERSION = "FW Version";
+
+  private CANSparkMax m_leftMotor;
+  private CANSparkMax m_rightMotor;
+
+  private int m_leftMotorDeviceHandle;
+  private int m_rightMotorDeviceHandle;
+
+  private SimDouble m_leftAppliedOutput;
+  private SimDouble m_rightAppliedOutput;
+
+  private SimDouble m_leftPositionMeters;
+  private SimDouble m_rightPositionMeters;
+
+  private SimDouble m_leftVelocityMetersPerSecond;
+  private SimDouble m_rightVelocityMetersPerSecond;
+
+  // Suggested code from https://pdocs.kauailabs.com/navx-mxp/software/roborio-libraries/java/
+  public static final String GYRO_DEVICE_NAME = "navX-Sensor[0]";
+  private SimDouble m_yaw;
+
+  private DifferentialDrivetrainSim m_drivetrainSim;
+
+  public DrivebaseSim(CANSparkMax leftMotor, CANSparkMax rightMotor) {
+    m_drivetrainSim = new DifferentialDrivetrainSim(
+      DCMotor.getNEO(2),
+      Drive.WHEEL_GEAR_RATIO,
+      // FIXME: These values are defaults from
+      // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.html
+      // and really should be measured.
+      7.5,
+      60.0,
+      // This value is the wheel radius in metres
+      Drive.WHEEL_CIRCUM / 100. / Math.PI / 2.,
+      Drive.TRACK_WIDTH_METERS,
+      // TODO: Add noise to the simulation here as standard deviation values for noise:
+      // x, y in m
+      // heading in rad
+      // l/r velocity m/s
+      // l/r position in m
+      VecBuilder.fill(0, 0, 0, 0, 0, 0, 0)
+    );
+
+    m_leftMotor = leftMotor;
+    m_rightMotor = rightMotor;
+    m_leftMotorDeviceHandle = SimDeviceDataJNI.getSimDeviceHandle("SPARK MAX [" + leftMotor.getDeviceId() + "]");
+    m_rightMotorDeviceHandle = SimDeviceDataJNI.getSimDeviceHandle("SPARK MAX [" + rightMotor.getDeviceId() + "]");
+    m_leftAppliedOutput = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_leftMotorDeviceHandle, DrivebaseSim.APPLIED_OUTPUT));
+    m_rightAppliedOutput = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_rightMotorDeviceHandle, DrivebaseSim.APPLIED_OUTPUT));
+    m_leftPositionMeters = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_leftMotorDeviceHandle, POSITION));
+    m_rightPositionMeters = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_rightMotorDeviceHandle, POSITION));
+    m_leftVelocityMetersPerSecond = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_leftMotorDeviceHandle, VELOCITY));
+    m_rightVelocityMetersPerSecond = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_rightMotorDeviceHandle, VELOCITY));
+
+    int gyroDeviceHandle = SimDeviceDataJNI.getSimDeviceHandle(GYRO_DEVICE_NAME);
+    m_yaw = new SimDouble(SimDeviceDataJNI.getSimValueHandle(gyroDeviceHandle, "Yaw"));
+  }
+
+  private void updateAppliedOutput() {
+    //m_leftAppliedOutput.set(1 * m_leftMotor.getBusVoltage());
+    //m_rightAppliedOutput.set(1 * m_rightMotor.getBusVoltage());
+    m_leftAppliedOutput.set(m_leftMotor.get() * m_leftMotor.getBusVoltage());
+    m_rightAppliedOutput.set(m_rightMotor.get() * m_rightMotor.getBusVoltage());
+  }
+
+  public void update(double period) {
+    this.updateAppliedOutput();
+    m_drivetrainSim.setInputs(m_leftMotor.getAppliedOutput(), m_rightMotor.getAppliedOutput());
+    m_drivetrainSim.update(period);
+    m_leftPositionMeters.set(m_drivetrainSim.getLeftPositionMeters());
+    m_rightPositionMeters.set(m_drivetrainSim.getRightPositionMeters());
+    m_leftVelocityMetersPerSecond.set(m_drivetrainSim.getLeftVelocityMetersPerSecond());
+    m_rightVelocityMetersPerSecond.set(m_drivetrainSim.getRightVelocityMetersPerSecond());
+    m_yaw.set(m_drivetrainSim.getHeading().getDegrees());
+  }
+
+  public static void printAllSimulationValues() {
+    DrivebaseSim.printSimulationValues("");
+  }
+
+  public static void printSimulationValues(String prefix) {
+    var deviceInfo = SimDeviceDataJNI.enumerateSimDevices(prefix);
+    for (var device : deviceInfo) {
+      var values = SimDeviceDataJNI.enumerateSimValues(device.handle);
+      for (var value : values) {
+        switch (value.value.getType()) {
+          case HALValue.kBoolean:
+            System.out.println(device.name + "." + value.name + ": (boolean): " + value.value.getBoolean());
+            break;
+          case HALValue.kDouble:
+            System.out.println(device.name + "." + value.name + ": (double): " + value.value.getDouble());
+            break;
+          case HALValue.kEnum:
+            System.out.println(device.name + "." + value.name + ": (enum): " + value.value.getLong());
+            break;
+          case HALValue.kInt:
+            System.out.println(device.name + "." + value.name + ": (int): " + value.value.getLong());
+            break;
+          case HALValue.kLong:
+            System.out.println(device.name + "." + value.name + ": (long): " + value.value.getLong());
+            break;
+          case HALValue.kUnassigned:
+            System.out.println(device.name + "." + value.name + ": (unassigned)");
+            break;
+          default:
+            System.out.println(device.name + "." + value.name + ": (unknown): " + value.value.getLong());
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -1,18 +1,13 @@
 package frc.robot.subsystems;
 
-import edu.wpi.first.hal.SimDouble;
-import edu.wpi.first.hal.simulation.SimDeviceDataJNI;
-import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.SPI;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
-import edu.wpi.first.wpilibj.simulation.DifferentialDrivetrainSim;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import java.util.List;
@@ -23,7 +18,6 @@ import com.pathplanner.lib.util.PathPlannerLogging;
 import com.pathplanner.lib.util.ReplanningConfig;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.REVLibError;
-import com.revrobotics.REVPhysicsSim;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
@@ -32,13 +26,13 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.DifferentialDriveKinematics;
 import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;
 import edu.wpi.first.math.kinematics.DifferentialDriveWheelSpeeds;
-import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.networktables.GenericEntry;
 
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 
 import frc.robot.Constants;
 import frc.robot.Constants.Drive;
+import frc.robot.sim.DrivebaseSim;
 
 public class DrivebaseSubsystem extends SubsystemBase {
 
@@ -53,11 +47,14 @@ public class DrivebaseSubsystem extends SubsystemBase {
   RelativeEncoder m_leftDriveEncoder;
   RelativeEncoder m_rightDriveEncoder;
 
+  private PIDController m_leftPid;
+  private PIDController m_rightPid;
+
   SlewRateLimiter filter = new SlewRateLimiter(0);
 
   private double m_scale = 1;
 
-  private DifferentialDrivetrainSim m_drivetrainSim;
+  private DrivebaseSim m_drivebaseSim;
 
   public double distanceDrivenAuto;
   public double rotationScale;
@@ -90,7 +87,9 @@ public class DrivebaseSubsystem extends SubsystemBase {
   ShuffleboardTab dashboardTab = Shuffleboard.getTab("Drivebase");
 
   // Turn on LTV path building instead of ramsete.
-  private boolean m_experimentalLTV = false;
+  private boolean m_experimentalLTV = true;
+  // Use PIDs in before calling tankDrive.
+  private boolean m_experimentalPID = true;
 
   /////////////////////////////
   // Simulation variables - would be nice to remove or minimize these to ensure there
@@ -128,7 +127,15 @@ public class DrivebaseSubsystem extends SubsystemBase {
     m_rightDriveMotorR.follow(m_rightDriveMotorF);
     m_rightDriveMotorF.setInverted(Constants.Drive.RIGHT_DRIVE_INVERTED);
 
+    m_leftDriveMotorF.getPIDController().setP(0.2);
+    m_rightDriveMotorF.getPIDController().setP(0.2);
+
     m_drive = new DifferentialDrive(m_leftDriveMotorF, m_rightDriveMotorF);
+    // If we don't want to use motor.set, we can control it more like this:
+    // m_drive = new DifferentialDrive(
+    //   (double value) -> m_leftDriveMotorF.getPIDController().setReference(value, ControlType.kDutyCycle),
+    //   (double value) -> m_rightDriveMotorF.getPIDController().setReference(value, ControlType.kDutyCycle)
+    // );
 
     setDrivebaseIdle(IdleMode.kBrake);
     m_leftDriveEncoder = m_leftDriveMotorF.getEncoder();
@@ -149,6 +156,10 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
     m_leftDriveEncoder.setPosition(0);
     m_rightDriveEncoder.setPosition(0);
+
+    // When we had no velocity, we liked kp=0.2
+    m_leftPid = new PIDController(15.9, 0, 0);
+    m_rightPid = new PIDController(15.9, 0, 0);
     
     rotationScaleWidget = dashboardTab.addPersistent("Driving Rotation Scale Factor", 0.76)
     .getEntry();
@@ -165,7 +176,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
     // Note: the dashboard listens to changes on the field object
     // so we don't have to publish changes explicitly.
     dashboardTab.add("Field2d", field);
-    m_kinematics = new DifferentialDriveKinematics(0.56);
+    m_kinematics = new DifferentialDriveKinematics(Drive.TRACK_WIDTH_METERS);
     driveOdometry = new DifferentialDriveOdometry(m_gyro.getRotation2d().unaryMinus(), getLDistance(), getRDistance());
 
     PathPlannerLogging.setLogActivePathCallback(this::saveActivePath);
@@ -175,7 +186,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
       AutoBuilder.configureLTV(
             this::getPose, // Robot pose supplier
             this::resetPose, // Method to reset odometry (will be called if your auto has a starting pose)
-            m_isSimulation ? this::getSimulationSpeeds : this::getCurrentSpeeds, // Current ChassisSpeeds supplier
+            this::getCurrentSpeeds, // Current ChassisSpeeds supplier
             this::drive, // Method that will drive the robot given ChassisSpeeds
             0.02, // duration in seconds between update loop calls, defaults to 0.02s = 20ms
             new ReplanningConfig(),
@@ -196,7 +207,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
       AutoBuilder.configureRamsete(
             this::getPose, // Robot pose supplier
             this::resetPose, // Method to reset odometry (will be called if your auto has a starting pose)
-            m_isSimulation ? this::getSimulationSpeeds : this::getCurrentSpeeds, // Current ChassisSpeeds supplier
+            this::getCurrentSpeeds, // Current ChassisSpeeds supplier
             this::drive, // Method that will drive the robot given ChassisSpeeds
             new ReplanningConfig(),
             () -> {
@@ -244,10 +255,26 @@ public class DrivebaseSubsystem extends SubsystemBase {
   }
 
   public void setPathPlannerSpeed(ChassisSpeeds speeds) {
+    final int maxSpeedMetersPerSecond = 5;
     DifferentialDriveWheelSpeeds wheelSpeeds = m_kinematics.toWheelSpeeds(speeds);
-    // wheelSpeeds.desaturate(0.5);
+    wheelSpeeds.desaturate(maxSpeedMetersPerSecond);
 
-    m_drive.tankDrive(wheelSpeeds.leftMetersPerSecond, wheelSpeeds.rightMetersPerSecond, false);
+    if (m_experimentalPID) {
+      // Weirdly there were times that it works better if we don't provide the velocity?
+      // Somehow the maxSpeedMetersPerSecond helps with that, because we are setting a speed control in [-1,1] but we
+      // get speeds from the path planner in meters per second and our simulation bot can go a little above 5 m/s.
+      //var leftOutput = m_leftPid.calculate(0, wheelSpeeds.leftMetersPerSecond);
+      //var rightOutput = m_rightPid.calculate(0, wheelSpeeds.rightMetersPerSecond);
+
+      var leftOutput = m_leftPid.calculate(m_leftDriveEncoder.getVelocity(), wheelSpeeds.leftMetersPerSecond);
+      var rightOutput = m_rightPid.calculate(m_rightDriveEncoder.getVelocity(), wheelSpeeds.rightMetersPerSecond);
+      //System.out.printf("%f %f %f, %f %f %f%n", m_leftDriveEncoder.getVelocity(), wheelSpeeds.leftMetersPerSecond, leftOutput, m_rightDriveEncoder.getVelocity(), wheelSpeeds.rightMetersPerSecond, rightOutput);
+      m_drive.tankDrive(leftOutput / maxSpeedMetersPerSecond, rightOutput / maxSpeedMetersPerSecond, false);
+    } else {
+      m_drive.tankDrive(wheelSpeeds.leftMetersPerSecond / maxSpeedMetersPerSecond, wheelSpeeds.rightMetersPerSecond / maxSpeedMetersPerSecond, false);
+    }
+    
+    
   }
 
   public void setScale(double scale) {
@@ -278,21 +305,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
     var speeds = m_kinematics.toChassisSpeeds(wheelSpeeds);
     return speeds;
   }
-
-  /**
-   * This really should just use getCurrentSpeeds, but unfortunately the REVPhysicsSim doesn't seem to support
-   * a way of setting the encoder velocity, so although the drivetrain simulator returns the simulated velocity,
-   * we can't write those values to the encoders. As a result, this is a copy of getCurrentSpeeds with the only
-   * difference being the source of velocity.
-   */
-  private ChassisSpeeds getSimulationSpeeds() {
-    var wheelSpeeds = new DifferentialDriveWheelSpeeds(
-      m_drivetrainSim.getLeftVelocityMetersPerSecond(),
-      m_drivetrainSim.getRightVelocityMetersPerSecond());
-    var speeds = m_kinematics.toChassisSpeeds(wheelSpeeds);
-    return speeds;
-  }
-  
+ 
   public void drive(ChassisSpeeds speeds){
     setPathPlannerSpeed(speeds);
   }
@@ -407,32 +420,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
   }
 
   public void onSimulationInit() {
-    m_drivetrainSim = new DifferentialDrivetrainSim(
-      DCMotor.getNEO(2),
-      Drive.WHEEL_GEAR_RATIO,
-      // FIXME: These values are defaults from
-      // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.html
-      // and really should be measured.
-      7.5,
-      60.0,
-      // This value is the wheel radius in metres
-      Drive.WHEEL_CIRCUM / 100. / Math.PI / 2.,
-      // FIXME: Turn this into a constant - it's used above as well.
-      0.56,
-      // TODO: Add noise to the simulation here as standard deviation values for noise:
-      // x, y in m
-      // heading in rad
-      // l/r velocity m/s
-      // l/r position in m
-      VecBuilder.fill(0, 0, 0, 0, 0, 0, 0)
-    );
-
-    // Add all the motors for simulation. Unknown if the rear motor simulation is needed
-    // or contributes anything.
-    REVPhysicsSim.getInstance().addSparkMax(m_leftDriveMotorF, DCMotor.getNEO(1));
-    REVPhysicsSim.getInstance().addSparkMax(m_leftDriveMotorR, DCMotor.getNEO(1));
-    REVPhysicsSim.getInstance().addSparkMax(m_rightDriveMotorF, DCMotor.getNEO(1));
-    REVPhysicsSim.getInstance().addSparkMax(m_rightDriveMotorR, DCMotor.getNEO(1));
+    m_drivebaseSim = new DrivebaseSim(m_leftDriveMotorF, m_rightDriveMotorF);
   }
 
   @Override
@@ -452,24 +440,6 @@ public class DrivebaseSubsystem extends SubsystemBase {
     final double period = (now - m_lastSimTime) / 1000000000.;
     m_lastSimTime = now;
 
-    // Run the REV physics simulation so that the motor values change
-    REVPhysicsSim.getInstance().run();
-
-    // Provide the drivetrain simulation inputs from the motors.
-    m_drivetrainSim.setInputs(m_leftDriveMotorF.get() * m_leftDriveMotorF.getBusVoltage(), m_rightDriveMotorF.get() * m_rightDriveMotorF.getBusVoltage());
-
-    // Run the drivetrain simulation for the same amount of time as the physics simulation ran.
-    m_drivetrainSim.update(period);
-
-    // Update the position encoders. NOTE: It would be great to update velocity here but we can't do it
-    // because the encoder we have has no method for updating velocity.
-    m_leftDriveEncoder.setPosition(m_drivetrainSim.getLeftPositionMeters());
-    m_rightDriveEncoder.setPosition(m_drivetrainSim.getRightPositionMeters());
-
-    // Update the gyro to match the simulated heading
-    // Suggested code from https://pdocs.kauailabs.com/navx-mxp/software/roborio-libraries/java/
-    int dev = SimDeviceDataJNI.getSimDeviceHandle("navX-Sensor[0]");
-    SimDouble angle = new SimDouble(SimDeviceDataJNI.getSimValueHandle(dev, "Yaw"));
-    angle.set(m_drivetrainSim.getHeading().getDegrees());
+    m_drivebaseSim.update(period);
   }
 }

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -14,8 +14,12 @@ import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.simulation.DifferentialDrivetrainSim;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+import java.util.List;
+
 import com.kauailabs.navx.frc.AHRS;
 import com.pathplanner.lib.auto.AutoBuilder;
+import com.pathplanner.lib.util.PathPlannerLogging;
 import com.pathplanner.lib.util.ReplanningConfig;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.REVLibError;
@@ -161,6 +165,8 @@ public class DrivebaseSubsystem extends SubsystemBase {
     m_kinematics = new DifferentialDriveKinematics(0.56);
     driveOdometry = new DifferentialDriveOdometry(m_gyro.getRotation2d().unaryMinus(), getLDistance(), getRDistance());
 
+    PathPlannerLogging.setLogActivePathCallback(this::saveActivePath);
+    PathPlannerLogging.setLogTargetPoseCallback(this::saveTargetPose);
     AutoBuilder.configureRamsete(
             this::getPose, // Robot pose supplier
             this::resetPose, // Method to reset odometry (will be called if your auto has a starting pose)
@@ -180,6 +186,14 @@ public class DrivebaseSubsystem extends SubsystemBase {
             },
             this // Reference to this subsystem to set requirements
     );
+  }
+
+  private void saveActivePath(List<Pose2d> activePath) {
+    field.getObject("activePath").setPoses(activePath);
+  }
+
+  private void saveTargetPose(Pose2d target) {
+    field.getObject("target").setPose(target);
   }
 
   public void setDrivebaseIdle(IdleMode setting) {

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -92,11 +92,15 @@ public class DrivebaseSubsystem extends SubsystemBase {
   private boolean m_experimentalPID = true;
 
   /////////////////////////////
-  // Simulation variables - would be nice to remove or minimize these to ensure there
+  // Simulation variables - would be nice to remove or minimize these to ensure
+  ///////////////////////////// there
   // is no impact on non-simulation performance.
   private boolean m_isSimulation = false;
 
-  /** Holds the last simulation time for duration calculation, matches REVPhysicsSim */
+  /**
+   * Holds the last simulation time for duration calculation, matches
+   * REVPhysicsSim
+   */
   private long m_lastSimTime;
 
   /** Allows first-time initialization of last simulation time. */
@@ -133,8 +137,10 @@ public class DrivebaseSubsystem extends SubsystemBase {
     m_drive = new DifferentialDrive(m_leftDriveMotorF, m_rightDriveMotorF);
     // If we don't want to use motor.set, we can control it more like this:
     // m_drive = new DifferentialDrive(
-    //   (double value) -> m_leftDriveMotorF.getPIDController().setReference(value, ControlType.kDutyCycle),
-    //   (double value) -> m_rightDriveMotorF.getPIDController().setReference(value, ControlType.kDutyCycle)
+    // (double value) -> m_leftDriveMotorF.getPIDController().setReference(value,
+    // ControlType.kDutyCycle),
+    // (double value) -> m_rightDriveMotorF.getPIDController().setReference(value,
+    // ControlType.kDutyCycle)
     // );
 
     setDrivebaseIdle(IdleMode.kBrake);
@@ -144,12 +150,15 @@ public class DrivebaseSubsystem extends SubsystemBase {
     // negative
 
     // Position is measured in motor revolutions by default, but we want metres.
-    // Wheel encoder scaling gives us centimetres and takes the gear ratio into account,
-    // and the scaling values appear to take more accurate wheel measurements and cm -> m
+    // Wheel encoder scaling gives us centimetres and takes the gear ratio into
+    // account,
+    // and the scaling values appear to take more accurate wheel measurements and cm
+    // -> m
     m_leftDriveEncoder.setPositionConversionFactor(Drive.WHEEL_ENCODER_SCALING * Drive.LEFT_SCALING);
     m_rightDriveEncoder.setPositionConversionFactor(Drive.WHEEL_ENCODER_SCALING * Drive.RIGHT_SCALING);
 
-    // Distance conversion is the same as the position factor, but convert from minutes to seconds
+    // Distance conversion is the same as the position factor, but convert from
+    // minutes to seconds
     // since velocity is measured in rpm by default but we want m/s.
     m_leftDriveEncoder.setVelocityConversionFactor(m_leftDriveEncoder.getPositionConversionFactor() / 60);
     m_rightDriveEncoder.setVelocityConversionFactor(m_rightDriveEncoder.getPositionConversionFactor() / 60);
@@ -158,11 +167,11 @@ public class DrivebaseSubsystem extends SubsystemBase {
     m_rightDriveEncoder.setPosition(0);
 
     // When we had no velocity, we liked kp=0.2
-    m_leftPid = new PIDController(15.9, 0, 0);
-    m_rightPid = new PIDController(15.9, 0, 0);
-    
+    m_leftPid = new PIDController(1.7, 0, 0);
+    m_rightPid = new PIDController(1.7, 0, 0);
+
     rotationScaleWidget = dashboardTab.addPersistent("Driving Rotation Scale Factor", 0.76)
-    .getEntry();
+        .getEntry();
 
     brakeModeWidget = dashboardTab.add("Brake Mode", false).getEntry();
     coastModeWidget = dashboardTab.add("Coast Mode", false).getEntry();
@@ -184,44 +193,46 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
     if (m_experimentalLTV) {
       AutoBuilder.configureLTV(
-            this::getPose, // Robot pose supplier
-            this::resetPose, // Method to reset odometry (will be called if your auto has a starting pose)
-            this::getCurrentSpeeds, // Current ChassisSpeeds supplier
-            this::drive, // Method that will drive the robot given ChassisSpeeds
-            0.02, // duration in seconds between update loop calls, defaults to 0.02s = 20ms
-            new ReplanningConfig(),
-            () -> {
-              // Boolean supplier that controls when the path will be mirrored for the red alliance
-              // This will flip the path being followed to the red side of the field.
-              // THE ORIGIN WILL REMAIN ON THE BLUE SIDE
+          this::getPose, // Robot pose supplier
+          this::resetPose, // Method to reset odometry (will be called if your auto has a starting pose)
+          this::getCurrentSpeeds, // Current ChassisSpeeds supplier
+          this::drive, // Method that will drive the robot given ChassisSpeeds
+          0.02, // duration in seconds between update loop calls, defaults to 0.02s = 20ms
+          new ReplanningConfig(),
+          () -> {
+            // Boolean supplier that controls when the path will be mirrored for the red
+            // alliance
+            // This will flip the path being followed to the red side of the field.
+            // THE ORIGIN WILL REMAIN ON THE BLUE SIDE
 
-              var alliance = DriverStation.getAlliance();
-              if (alliance.isPresent()) {
-                return alliance.get() == DriverStation.Alliance.Red;
-              }
-              return false;
-            },
-            this // Reference to this subsystem to set requirements
+            var alliance = DriverStation.getAlliance();
+            if (alliance.isPresent()) {
+              return alliance.get() == DriverStation.Alliance.Red;
+            }
+            return false;
+          },
+          this // Reference to this subsystem to set requirements
       );
     } else {
       AutoBuilder.configureRamsete(
-            this::getPose, // Robot pose supplier
-            this::resetPose, // Method to reset odometry (will be called if your auto has a starting pose)
-            this::getCurrentSpeeds, // Current ChassisSpeeds supplier
-            this::drive, // Method that will drive the robot given ChassisSpeeds
-            new ReplanningConfig(),
-            () -> {
-              // Boolean supplier that controls when the path will be mirrored for the red alliance
-              // This will flip the path being followed to the red side of the field.
-              // THE ORIGIN WILL REMAIN ON THE BLUE SIDE
+          this::getPose, // Robot pose supplier
+          this::resetPose, // Method to reset odometry (will be called if your auto has a starting pose)
+          this::getCurrentSpeeds, // Current ChassisSpeeds supplier
+          this::drive, // Method that will drive the robot given ChassisSpeeds
+          new ReplanningConfig(),
+          () -> {
+            // Boolean supplier that controls when the path will be mirrored for the red
+            // alliance
+            // This will flip the path being followed to the red side of the field.
+            // THE ORIGIN WILL REMAIN ON THE BLUE SIDE
 
-              var alliance = DriverStation.getAlliance();
-              if (alliance.isPresent()) {
-                return alliance.get() == DriverStation.Alliance.Red;
-              }
-              return false;
-            },
-            this // Reference to this subsystem to set requirements
+            var alliance = DriverStation.getAlliance();
+            if (alliance.isPresent()) {
+              return alliance.get() == DriverStation.Alliance.Red;
+            }
+            return false;
+          },
+          this // Reference to this subsystem to set requirements
       );
     }
   }
@@ -241,7 +252,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
     m_leftDriveMotorR.setIdleMode(setting);
   }
 
-  public void disable(){
+  public void disable() {
     setDrivebaseIdle(IdleMode.kBrake);
   }
 
@@ -255,26 +266,32 @@ public class DrivebaseSubsystem extends SubsystemBase {
   }
 
   public void setPathPlannerSpeed(ChassisSpeeds speeds) {
-    final int maxSpeedMetersPerSecond = 5;
+    final double maxSpeedMetersPerSecond = 4;
     DifferentialDriveWheelSpeeds wheelSpeeds = m_kinematics.toWheelSpeeds(speeds);
     wheelSpeeds.desaturate(maxSpeedMetersPerSecond);
 
     if (m_experimentalPID) {
-      // Weirdly there were times that it works better if we don't provide the velocity?
-      // Somehow the maxSpeedMetersPerSecond helps with that, because we are setting a speed control in [-1,1] but we
-      // get speeds from the path planner in meters per second and our simulation bot can go a little above 5 m/s.
-      //var leftOutput = m_leftPid.calculate(0, wheelSpeeds.leftMetersPerSecond);
-      //var rightOutput = m_rightPid.calculate(0, wheelSpeeds.rightMetersPerSecond);
+      // Weirdly there were times that it works better if we don't provide the
+      // velocity?
+      // Somehow the maxSpeedMetersPerSecond helps with that, because we are setting a
+      // speed control in [-1,1] but we
+      // get speeds from the path planner in meters per second and our simulation bot
+      // can go a little above 5 m/s.
+      // var leftOutput = m_leftPid.calculate(0, wheelSpeeds.leftMetersPerSecond);
+      // var rightOutput = m_rightPid.calculate(0, wheelSpeeds.rightMetersPerSecond);
 
       var leftOutput = m_leftPid.calculate(m_leftDriveEncoder.getVelocity(), wheelSpeeds.leftMetersPerSecond);
       var rightOutput = m_rightPid.calculate(m_rightDriveEncoder.getVelocity(), wheelSpeeds.rightMetersPerSecond);
-      //System.out.printf("%f %f %f, %f %f %f%n", m_leftDriveEncoder.getVelocity(), wheelSpeeds.leftMetersPerSecond, leftOutput, m_rightDriveEncoder.getVelocity(), wheelSpeeds.rightMetersPerSecond, rightOutput);
+      // System.out.printf("%f %f %f, %f %f %f%n", m_leftDriveEncoder.getVelocity(),
+      // wheelSpeeds.leftMetersPerSecond, leftOutput,
+      // m_rightDriveEncoder.getVelocity(), wheelSpeeds.rightMetersPerSecond,
+      // rightOutput);
       m_drive.tankDrive(leftOutput / maxSpeedMetersPerSecond, rightOutput / maxSpeedMetersPerSecond, false);
     } else {
-      m_drive.tankDrive(wheelSpeeds.leftMetersPerSecond / maxSpeedMetersPerSecond, wheelSpeeds.rightMetersPerSecond / maxSpeedMetersPerSecond, false);
+      m_drive.tankDrive(wheelSpeeds.leftMetersPerSecond / maxSpeedMetersPerSecond,
+          wheelSpeeds.rightMetersPerSecond / maxSpeedMetersPerSecond, false);
     }
-    
-    
+
   }
 
   public void setScale(double scale) {
@@ -282,11 +299,10 @@ public class DrivebaseSubsystem extends SubsystemBase {
   }
 
   // Get the pose of the robot as Pose2d
-  public Pose2d getPose(){
+  public Pose2d getPose() {
     var pose = driveOdometry.getPoseMeters();
     return pose;
   }
-
 
   // Reset the Pose2d of the robot
   // This gets called if the path has an initial pose - which ours does.
@@ -301,12 +317,13 @@ public class DrivebaseSubsystem extends SubsystemBase {
   }
 
   public ChassisSpeeds getCurrentSpeeds() {
-    var wheelSpeeds = new DifferentialDriveWheelSpeeds(m_leftDriveEncoder.getVelocity(), m_rightDriveEncoder.getVelocity());
+    var wheelSpeeds = new DifferentialDriveWheelSpeeds(m_leftDriveEncoder.getVelocity(),
+        m_rightDriveEncoder.getVelocity());
     var speeds = m_kinematics.toChassisSpeeds(wheelSpeeds);
     return speeds;
   }
- 
-  public void drive(ChassisSpeeds speeds){
+
+  public void drive(ChassisSpeeds speeds) {
     setPathPlannerSpeed(speeds);
   }
 
@@ -362,32 +379,32 @@ public class DrivebaseSubsystem extends SubsystemBase {
     // We're trying both (before checking failures, so we can
     // track whether just one or both fail), and returning
     // if all is well, but otherwise counting the failures and
-    // retrying.  We'll print the stats as we change states.
+    // retrying. We'll print the stats as we change states.
     for (int i = 0; i < 5; i++) {
-      // Reset but check that return code is good.  In a future world
+      // Reset but check that return code is good. In a future world
       // we can do more like recording the specific error code, but
       // since we're adding this mid-competition I want to be conservative.
       boolean leftOk = m_leftDriveEncoder.setPosition(0) == REVLibError.kOk;
       boolean rightOk = m_rightDriveEncoder.setPosition(0) == REVLibError.kOk;
 
       if (leftOk && rightOk) {
-          break;  // Success! Get us out of here.
+        break; // Success! Get us out of here.
       } else {
-          if (!leftOk)
-              leftErrorCount += 1;
-          if (!rightOk)
-              rightErrorCount += 1;
+        if (!leftOk)
+          leftErrorCount += 1;
+        if (!rightOk)
+          rightErrorCount += 1;
       }
     }
   }
 
   public void reportFailures(String state) {
     System.out.printf("Reset failures (%s): %d, %d%n",
-      state, leftErrorCount, rightErrorCount);
+        state, leftErrorCount, rightErrorCount);
   }
 
   @Override
-  public void periodic(){
+  public void periodic() {
     driveOdometry.update(m_gyro.getRotation2d().unaryMinus(), getLDistance(), getRDistance());
     rotationScale = rotationScaleWidget.getDouble(0.76);
     leftDistanceWidget.setDouble(getLDistance());
@@ -396,27 +413,27 @@ public class DrivebaseSubsystem extends SubsystemBase {
     // This publishes changes through to the dashboard.
     field.setRobotPose(driveOdometry.getPoseMeters());
 
-    if (isBrakeMode != brakeModeWidget.getBoolean(false)){
+    if (isBrakeMode != brakeModeWidget.getBoolean(false)) {
       isBrakeMode = brakeModeWidget.getBoolean(false);
-      if (isBrakeMode){
+      if (isBrakeMode) {
         setDrivebaseIdle(IdleMode.kBrake);
       }
 
-    if (isCoastMode != coastModeWidget.getBoolean(false)){
-      isCoastMode = coastModeWidget.getBoolean(false);
-      if (isCoastMode){
-        setDrivebaseIdle(IdleMode.kCoast);
-      }
+      if (isCoastMode != coastModeWidget.getBoolean(false)) {
+        isCoastMode = coastModeWidget.getBoolean(false);
+        if (isCoastMode) {
+          setDrivebaseIdle(IdleMode.kCoast);
+        }
       }
     }
-      navxMonitorWidget.setDouble(m_gyro.getAngle());
+    navxMonitorWidget.setDouble(m_gyro.getAngle());
 
-      counter++;
+    counter++;
 
-      if (counter == 50){
-        counter = 0;
-      }
-      counterWidget.setDouble(counter);
+    if (counter == 50) {
+      counter = 0;
+    }
+    counterWidget.setDouble(counter);
   }
 
   public void onSimulationInit() {
@@ -425,12 +442,16 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
   @Override
   public void simulationPeriodic() {
-    // This code is basically a duplicate of the getPeriod method in REVPhysicsSim.SimProfile.
-    // It would be much better for debugging if we could simulate time passing rather than
-    // run it in realtime, but unfortunately we have at least two different timers running
+    // This code is basically a duplicate of the getPeriod method in
+    // REVPhysicsSim.SimProfile.
+    // It would be much better for debugging if we could simulate time passing
+    // rather than
+    // run it in realtime, but unfortunately we have at least two different timers
+    // running
     // 1. Command scheduler timer
     // 2. REVPhysicsSim.SimProfile uses System.nanoTime
-    // We want to ensure that our drivetrain simulator does its update with an equivalent
+    // We want to ensure that our drivetrain simulator does its update with an
+    // equivalent
     // duration, so it's copied here for now.
     if (!m_startedSimulation) {
       m_lastSimTime = System.nanoTime();


### PR DESCRIPTION
A few things done here:
- Add experimental LTV controller option.
- Add PID controllers for left and right motors so that the Ramsete/LTV controller output is smoothed out.
- Remove the broken RevPhysicsSim and replace it with our own custom simulation.
- Scale drive values in m/s into normalized values based on the maximum linear speed of the robot (approximately 3.86 m/s) and then normalize that to [-1,1] for the motor controller.
- Work on tuning the PID constants (0.7 and 1.7 seem to give good results)

Result: Path planning and trajectory following is much better and smoother.